### PR TITLE
add chat restriction duration

### DIFF
--- a/bot/framework/system/telegram_types.py
+++ b/bot/framework/system/telegram_types.py
@@ -18,3 +18,4 @@ ChatMember = types.ChatMember
 ChatMemberAdministrator = types.ChatMemberAdministrator
 ChatMemberOwner = types.ChatMemberOwner
 ChatAdministratorRights = types.ChatAdministratorRights
+ChatPermissions = types.ChatPermissions

--- a/bot/pkg/config/routes.py
+++ b/bot/pkg/config/routes.py
@@ -31,6 +31,7 @@ class RoutesInterface(TypedDict):
     chat: RouteInterface
     add_to_chat_whitelist: RouteInterface
     chat_whitelist: RouteInterface
+    chat_restriction_duration: RouteInterface
     allowed_user: RouteInterface
     subscription: RouteInterface
     tariffs: RouteInterface
@@ -90,7 +91,8 @@ class RouteMap:
             'available_from': ['call'],
             'routes': [
                 'add_to_chat_whitelist',
-                'chat_whitelist'
+                'chat_whitelist',
+                'chat_restriction_duration'
             ],
             'actions': {
                 'switch_active': {
@@ -112,6 +114,12 @@ class RouteMap:
             'method': allowed_users_controller.chat_whitelist,
             'available_from': ['message', 'call'],
             'routes': ['allowed_user'],
+            'wait_for_input': True,
+            'validator': chat_access_validator
+        },
+        'chat_restriction_duration': {
+            'method': chats_controller.restriction_duration,
+            'available_from': ['message', 'call'],
             'wait_for_input': True,
             'validator': chat_access_validator
         },

--- a/bot/pkg/config/routes_dict.py
+++ b/bot/pkg/config/routes_dict.py
@@ -3,7 +3,7 @@ from typing import Literal
 AvailableCommands = Literal['start', 'menu', 'add_chat', 'my_chats', 'subscription']
 AvailableRoutes = Literal[
     'start', 'privacy', 'help', 'menu', 'add_chat', 'my_chats', 'chat',
-    'add_to_chat_whitelist', 'chat_whitelist', 'allowed_user',
+    'add_to_chat_whitelist', 'chat_whitelist', 'allowed_user', 'chat_restriction_duration',
     'subscription', 'tariffs', 'fund', 'fund_currency', 'fund_amount',
     'settings', 'settings_email', 'settings_currency',
     'nowhere']

--- a/bot/pkg/controller/user_controllers/chats_controller.py
+++ b/bot/pkg/controller/user_controllers/chats_controller.py
@@ -15,6 +15,8 @@ from pkg.service.chat import Chat
 from project.types import ModeratedChatInterface
 
 _PER_PAGE = 5
+_MIN_RESTRICTION_DURATION_MINUTES = 1
+_MAX_RESTRICTION_DURATION_MINUTES = 1440
 
 
 async def add_chat(params: ControllerParams):
@@ -208,6 +210,14 @@ async def show(params: ControllerParams):
         'callback_data': {'tp': 'chat_whitelist'}}
     reply_markup.append([whitelist_button])
 
+    restriction_duration_button = {
+        'text': localization.get_message(
+            ['chat', 'show', 'restriction_duration_button'],
+            params['language_code'],
+            duration=chat_data.get('restriction_duration_minutes', 5)),
+        'callback_data': {'tp': 'chat_restriction_duration'}}
+    reply_markup.append([restriction_duration_button])
+
     state_button = {
         'text': localization.get_message(
             [
@@ -237,6 +247,89 @@ async def show(params: ControllerParams):
     await message_sender(message.chat.id, message_structures=message_structures)
 
     UserStorage.add_user_state_data(message.chat.id, 'chat', {**params['state_data'], **chat_data})
+
+
+async def restriction_duration(params: ControllerParams):
+    call, message = params['call'], params['message']
+    chat_state_data = state_data.get_local_state_data(message, routes.RouteMap.type('chat'))
+
+    if 'id' not in chat_state_data:
+        await raise_error(None, message, 'state_data_none')
+        return False
+
+    if is_call_or_command(call, message):
+        chat_data = await Chat.find(chat_state_data['id'])
+        if chat_data is None:
+            await notify(
+                call, message, localization.get_message(['chat', 'errors', 'not_found'], params['language_code']))
+            return False
+
+        restriction_access = await Chat.validate_restriction_access(int(chat_data['service_id']))
+        if 'error' in restriction_access:
+            await notify(call, message, localization.get_message(
+                ['chat', 'restriction_duration', 'warnings', restriction_access['error']],
+                params['language_code']), alert=True)
+
+        message_structures = [{
+            'type': 'text',
+            'text': localization.get_message(
+                ['chat', 'restriction_duration', 'text'],
+                params['language_code'],
+                duration=chat_data.get('restriction_duration_minutes', 5),
+                min_duration=_MIN_RESTRICTION_DURATION_MINUTES,
+                max_duration=_MAX_RESTRICTION_DURATION_MINUTES),
+            'reply_markup': go_back_inline_markup(params['language_code']),
+            'parse_mode': 'HTML'
+        }]
+        await message_sender(message.chat.id, message_structures=message_structures)
+        return
+
+    try:
+        duration_minutes = int(message.text)
+    except ValueError:
+        await notify(None, message, localization.get_message(
+            ['chat', 'restriction_duration', 'errors', 'invalid'],
+            params['language_code'],
+            min_duration=_MIN_RESTRICTION_DURATION_MINUTES,
+            max_duration=_MAX_RESTRICTION_DURATION_MINUTES), save_state=True, button_text='cancel')
+        return False
+
+    if (
+            duration_minutes < _MIN_RESTRICTION_DURATION_MINUTES
+            or duration_minutes > _MAX_RESTRICTION_DURATION_MINUTES):
+        await notify(None, message, localization.get_message(
+            ['chat', 'restriction_duration', 'errors', 'invalid'],
+            params['language_code'],
+            min_duration=_MIN_RESTRICTION_DURATION_MINUTES,
+            max_duration=_MAX_RESTRICTION_DURATION_MINUTES), save_state=True, button_text='cancel')
+        return False
+
+    duration_minutes = await Chat.update_restriction_duration(chat_state_data['id'], duration_minutes)
+    chat_state_data['restriction_duration_minutes'] = duration_minutes
+    UserStorage.add_user_state_data(message.chat.id, 'chat', chat_state_data)
+
+    chat_data = await Chat.find(chat_state_data['id'])
+    if chat_data is None:
+        await notify(
+            None, message, localization.get_message(['chat', 'errors', 'not_found'], params['language_code']))
+        return False
+
+    restriction_access = await Chat.validate_restriction_access(int(chat_data['service_id']))
+    if 'error' in restriction_access:
+        result_message = localization.get_message(
+            ['chat', 'restriction_duration', 'success_with_warning'],
+            params['language_code'],
+            duration=duration_minutes)
+        result_message += "\n\n" + localization.get_message(
+            ['chat', 'restriction_duration', 'warnings', restriction_access['error']],
+            params['language_code'])
+    else:
+        result_message = localization.get_message(
+            ['chat', 'restriction_duration', 'success'],
+            params['language_code'],
+            duration=duration_minutes)
+
+    await notify(None, message, result_message, save_state=True)
 
 
 async def switch_active(params: ControllerParams):

--- a/bot/pkg/controller/work_controllers/chat_incoming_controller.py
+++ b/bot/pkg/controller/work_controllers/chat_incoming_controller.py
@@ -6,6 +6,10 @@ from pkg.system.logger import logger
 
 
 async def incoming_chat_message(message: telegram_types.Message):
+    if message.from_user is None:
+        logger.warning("Incoming chat message has no sender")
+        return
+
     # Ignore messages sent by bots
     if message.from_user.is_bot:  # and message.from_user.username != 'GroupAnonymousBot'
         return

--- a/bot/pkg/controller/work_controllers/chat_incoming_controller.py
+++ b/bot/pkg/controller/work_controllers/chat_incoming_controller.py
@@ -30,6 +30,9 @@ async def incoming_chat_message(message: telegram_types.Message):
 
     try:
         await message.delete()
+    except telegram_exceptions.TelegramForbiddenError as e:
+        logger.warning(e)
+        return
     except telegram_exceptions.TelegramBadRequest as e:
         if "message can't be deleted" in str(e):
             return
@@ -38,3 +41,13 @@ async def incoming_chat_message(message: telegram_types.Message):
             return
 
         logger.error(e)
+        return
+    except Exception as e:
+        logger.error(e)
+        return
+
+    await Chat.restrict_user(
+        chat_service_id,
+        message.from_user.id,
+        chat_data.get('restriction_duration_minutes', 5),
+        message.chat.type)

--- a/bot/pkg/repository/chat_repository.py
+++ b/bot/pkg/repository/chat_repository.py
@@ -173,6 +173,12 @@ async def switch_active(chat_id: int) -> bool:
     """, (chat_id,), returning='active'))['active']
 
 
+async def update_restriction_duration(chat_id: int, duration_minutes: int) -> int:
+    return (await databaseExecutor.run(db.execute_single_model, """
+        UPDATE moderated_chats SET restriction_duration_minutes = %s WHERE id = %s
+    """, (duration_minutes, chat_id,), returning='restriction_duration_minutes'))['restriction_duration_minutes']
+
+
 async def delete(chat_id: int) -> int | None:
     connection: Connection
     async with db.get_connection() as connection:

--- a/bot/pkg/service/chat.py
+++ b/bot/pkg/service/chat.py
@@ -1,3 +1,4 @@
+import datetime
 import typing
 from typing import TypedDict, List, Literal
 
@@ -25,6 +26,10 @@ class AccessValidationInterface(ErrorDictInterface, total=False):
 
 class Chat(Service):
     BOT = bot
+
+    @staticmethod
+    def _chat_type_value(chat_type) -> str:
+        return getattr(chat_type, 'value', chat_type)
 
     @staticmethod
     async def find(chat_id: int) -> ModeratedChatInterface | None:
@@ -220,6 +225,61 @@ class Chat(Service):
     @staticmethod
     async def switch_active(chat_id: int) -> bool:
         return await chat_repository.switch_active(chat_id)
+
+    @staticmethod
+    async def update_restriction_duration(chat_id: int, duration_minutes: int) -> int:
+        return await chat_repository.update_restriction_duration(chat_id, duration_minutes)
+
+    @classmethod
+    async def validate_restriction_access(cls, chat_service_id: int) -> ErrorDictInterface:
+        try:
+            chat_info = await cls.BOT.get_chat(chat_service_id)
+        except telegram_exceptions.TelegramForbiddenError:
+            return {'error': 'not_member'}
+        except telegram_exceptions.TelegramBadRequest:
+            return {'error': 'not_found'}
+        except Exception as e:
+            logger.error(e)
+            return {'error': 'unknown'}
+
+        if cls._chat_type_value(chat_info.type) != 'supergroup':
+            return {'error': 'restriction_supergroup_required'}
+
+        chat_member = await cls._get_chat_member(chat_service_id, bot.id)
+        if 'error' in chat_member:
+            return {'error': chat_member['error']}
+
+        bot_rights_validation = await cls._validate_bot_rights(chat_member)
+        if 'error' in bot_rights_validation:
+            return {'error': bot_rights_validation['error']}
+
+        if isinstance(chat_member, telegram_types.ChatMemberOwner):
+            return {}
+
+        if isinstance(chat_member, telegram_types.ChatMemberAdministrator) and chat_member.can_restrict_members:
+            return {}
+
+        return {'error': 'cant_restrict_members'}
+
+    @classmethod
+    async def restrict_user(
+            cls, chat_service_id: int, user_service_id: int, duration_minutes: int, chat_type: str | None = None):
+        if duration_minutes <= 0 or cls._chat_type_value(chat_type) != 'supergroup':
+            return
+
+        try:
+            until_date = (
+                datetime.datetime.now(datetime.timezone.utc)
+                + datetime.timedelta(minutes=duration_minutes))
+            await cls.BOT.restrict_chat_member(
+                chat_id=chat_service_id,
+                user_id=user_service_id,
+                permissions=telegram_types.ChatPermissions(can_send_messages=False),
+                until_date=until_date)
+        except (telegram_exceptions.TelegramBadRequest, telegram_exceptions.TelegramForbiddenError) as e:
+            logger.warning(e)
+        except Exception as e:
+            logger.error(e)
 
     @staticmethod
     async def delete(chat_id: int, user_service_id: int) -> int | ErrorDictInterface:

--- a/bot/project/i18n.py
+++ b/bot/project/i18n.py
@@ -359,6 +359,10 @@ routed_messages = {
                 'en': "Add to allowed users",
                 'ru': "Добавить в белый список"
             },
+            'restriction_duration_button': {
+                'en': "Restriction: {duration} min",
+                'ru': "Ограничение: {duration} мин"
+            },
             'active_button': {
                 'active': {
                     'en': emoji_codes.get('heavy_check_mark', '') + " Chat is connected",
@@ -384,6 +388,90 @@ routed_messages = {
             'confirm': {
                 'en': "Click the button again to delete",
                 'ru': "Для удаления нажмите на кнопку ещё раз"
+            }
+        },
+        'restriction_duration': {
+            'text': {
+                'en':
+                    "Current restriction time: <b>{duration} min</b>\n\n"
+                    "Send a number from {min_duration} to {max_duration}. "
+                    "Users outside the allowed list will be restricted for this time after their message is deleted.",
+                'ru':
+                    "Текущее время ограничения: <b>{duration} мин</b>\n\n"
+                    "Пришлите число от {min_duration} до {max_duration}. "
+                    "Пользователи вне белого списка будут ограничены на это время после удаления сообщения."
+            },
+            'success': {
+                'en': "Restriction time saved: {duration} min",
+                'ru': "Время ограничения сохранено: {duration} мин"
+            },
+            'success_with_warning': {
+                'en': "Restriction time saved: {duration} min, but temporary restriction needs attention.",
+                'ru': "Время ограничения сохранено: {duration} мин, но временное ограничение требует внимания."
+            },
+            'errors': {
+                'invalid': {
+                    'en': "Send a whole number from {min_duration} to {max_duration}",
+                    'ru': "Пришлите целое число от {min_duration} до {max_duration}"
+                }
+            },
+            'warnings': {
+                'restriction_supergroup_required': {
+                    'en':
+                        "Temporary restriction works only in supergroups. "
+                        "Messages outside the allowed list will still be deleted.",
+                    'ru':
+                        "Временное ограничение работает только в супергруппах. "
+                        "Сообщения вне белого списка всё равно будут удаляться."
+                },
+                'cant_restrict_members': {
+                    'en':
+                        "The bot needs administrator permission to restrict members. "
+                        "Messages outside the allowed list will still be deleted.",
+                    'ru':
+                        "Боту нужны права администратора на ограничение участников. "
+                        "Сообщения вне белого списка всё равно будут удаляться."
+                },
+                'not_member': {
+                    'en':
+                        "The bot is not a chat member. "
+                        "Messages can be moderated again after the bot is added as an administrator.",
+                    'ru':
+                        "Бота нет в группе. "
+                        "Модерация продолжит работать после добавления бота администратором."
+                },
+                'not_found': {
+                    'en':
+                        "The chat was not found. "
+                        "Check that the bot is still in the chat and has administrator permissions.",
+                    'ru':
+                        "Группа не найдена. "
+                        "Проверьте, что бот всё ещё в группе и имеет права администратора."
+                },
+                'not_admin': {
+                    'en':
+                        "The bot must be a chat administrator. "
+                        "Messages outside the allowed list will be deleted only when delete permission is available.",
+                    'ru':
+                        "Бот должен быть администратором группы. "
+                        "Сообщения вне белого списка будут удаляться только при наличии права удаления."
+                },
+                'cant_edit_messages': {
+                    'en':
+                        "The bot needs permission to delete messages. "
+                        "Temporary restriction is an addition to deletion, not a replacement.",
+                    'ru':
+                        "Боту нужны права на удаление сообщений. "
+                        "Временное ограничение дополняет удаление, а не заменяет его."
+                },
+                'unknown': {
+                    'en':
+                        "Restriction permissions could not be checked. "
+                        "Messages outside the allowed list will still be deleted when possible.",
+                    'ru':
+                        "Не удалось проверить права на ограничение. "
+                        "Сообщения вне белого списка всё равно будут удаляться, если это возможно."
+                }
             }
         },
         'add_to_whitelist': {

--- a/bot/project/types.py
+++ b/bot/project/types.py
@@ -28,6 +28,7 @@ class ModeratedChatInterface(TypedDict, total=False):
     created_at: datetime.datetime
     updated_at: datetime.datetime
     name: str
+    restriction_duration_minutes: int
 
 
 class UserModeratedChatConnectionInterface(TypedDict, total=False):

--- a/migrator/db/migrations/20260628120000_add_chat_restriction_duration.sql
+++ b/migrator/db/migrations/20260628120000_add_chat_restriction_duration.sql
@@ -1,0 +1,10 @@
+-- migrate:up
+
+alter table moderated_chats
+add column restriction_duration_minutes integer not null default 5;
+
+
+-- migrate:down
+
+alter table moderated_chats
+drop column restriction_duration_minutes;

--- a/migrator/db/schema.sql
+++ b/migrator/db/schema.sql
@@ -125,7 +125,8 @@ CREATE TABLE public.moderated_chats (
     allowed_keywords character varying(255)[],
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    name character varying(255)
+    name character varying(255),
+    restriction_duration_minutes integer DEFAULT 5 NOT NULL
 );
 
 


### PR DESCRIPTION
## Summary

Re-targets the chat restriction duration changes onto the production branch `main`. PR #49 was accidentally merged into `feature/multi-currency-balances`; this branch cherry-picks only the restriction changes on top of current `main`.

## Changes

- Adds per-chat restriction duration with default 5 minutes.
- Deletes disallowed messages first, then best-effort restricts the sender in supergroups.
- Adds chat settings UI and i18n warnings for missing rights or unsupported chat type.
- Adds dbmate migration for `moderated_chats.restriction_duration_minutes`.

## Validation

- `git diff --check origin/main..HEAD`
- `python3 -m py_compile` for changed Python files
