### PR TITLE
fix production deploy schema handling

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,9 +31,11 @@ jobs:
           username: ${{ secrets.SERVER_USERNAME }}
           password: ${{ secrets.SERVER_PASSWORD }}
           script: |
+            set -eu
             cd ${{ secrets.PROJECT_PATH }}
-            git pull
-            docker system prune -f
+            git restore migrator/db/schema.sql
+            git pull --ff-only origin main
             docker compose -f docker-compose.yml -f docker-compose.prod.yml build
-            docker compose -f docker-compose.yml -f docker-compose.prod.yml stop -t 1 bot
-            docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+            docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d db storage
+            docker compose -f docker-compose.yml -f docker-compose.prod.yml run --rm migrator
+            docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --no-deps bot

--- a/README.md
+++ b/README.md
@@ -60,4 +60,6 @@ Migrate with
 View help and rest of the commands with  
 `docker compose run migrator --help`
 
+Commit `migrator/db/schema.sql` together with migrations after running dbmate locally or in a controlled development environment. Production should apply migrations without writing schema dumps back into the server checkout.
+
 Don't forget to own the project if necessary.

--- a/bot/Dockerfile
+++ b/bot/Dockerfile
@@ -2,10 +2,12 @@
 FROM python:3.11 as base
 # set work directory
 WORKDIR /usr/src/bot/
+
+COPY requirements.txt /usr/src/bot/
+RUN pip install -r requirements.txt # Install packages from requirements.txt
+
 # copy project
 COPY . /usr/src/bot/
-
-RUN pip install -r requirements.txt # Install packages from requirements.txt
 
 # RUN pip-upgrade --skip-virtualenv-check # Interactively upgrade packages from requirements file, and also update the pinned version from requirements file(s).
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -18,6 +18,7 @@ services:
   migrator:
     build:
       target: prod
+    volumes: !reset []
     env_file:
       - env/.env
       - env/.env.prod
@@ -28,5 +29,4 @@ services:
       - env/.env
       - env/.env.prod
       - env/.env.local
-
 


### PR DESCRIPTION
## Summary

Makes production deploys stop mutating the git checkout and fail on real deployment errors.

## Changes

- Removes the inherited migrator bind mount in production with `volumes: !reset []`, so dbmate cannot rewrite `migrator/db/schema.sql` on the server checkout.
- Restores `migrator/db/schema.sql` before pulling on production, so the known schema-dump drift cannot block deploys.
- Uses `git pull --ff-only origin main` and `set -eu` so real deploy failures stop the workflow.
- Removes `docker system prune -f` from the normal deploy path.
- Runs migrations explicitly before updating the bot container.
- Caches Python dependency installs by copying `requirements.txt` before the application code in the bot Dockerfile.
- Documents that `schema.sql` should be generated locally/dev/CI and committed with migrations.

## Validation

- `git diff --check`
- `docker compose -f docker-compose.yml -f docker-compose.prod.yml config`
- Verified rendered prod migrator config has no volumes
- Static checks for workflow/Dockerfile/deploy command ordering

Local migration execution was not run because Docker daemon is not available on this machine.
